### PR TITLE
✨ #48 - querydsl 사용해서 post의 title과 content내에 있는 keyword 검색 & keyword table에 저장

### DIFF
--- a/src/main/kotlin/org/teamsparta/moviereview/domain/post/controller/v1/PostController.kt
+++ b/src/main/kotlin/org/teamsparta/moviereview/domain/post/controller/v1/PostController.kt
@@ -15,10 +15,7 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
-import org.teamsparta.moviereview.domain.post.dto.CreatePostRequest
-import org.teamsparta.moviereview.domain.post.dto.PostResponse
-import org.teamsparta.moviereview.domain.post.dto.PostResponseWithComments
-import org.teamsparta.moviereview.domain.post.dto.UpdatePostRequest
+import org.teamsparta.moviereview.domain.post.dto.*
 import org.teamsparta.moviereview.domain.post.dto.report.ReportPostRequest
 import org.teamsparta.moviereview.domain.post.service.v1.PostService
 import org.teamsparta.moviereview.infra.security.UserPrincipal
@@ -38,7 +35,7 @@ class PostController(
     }
 
     @GetMapping("{postId}")
-    fun getPostById(@PathVariable postId:Long): ResponseEntity<PostResponseWithComments> {
+    fun getPostById(@PathVariable postId: Long): ResponseEntity<PostResponseWithComments> {
         return ResponseEntity.ok(postService.getPostById(postId))
     }
 
@@ -71,9 +68,10 @@ class PostController(
 
     @GetMapping("/search")
     fun searchPost(
+        pageable: Pageable,
         @RequestParam keyword: String,
-        ) : ResponseEntity<List<PostResponse>> {
-        return ResponseEntity.ok(postService.searchPost(keyword))
+    ): ResponseEntity<Page<PostResponseWithThumbsUpAndComments>> {
+        return ResponseEntity.status(HttpStatus.OK).body(postService.searchPost(pageable, keyword))
     }
 
     @PostMapping("/{postId}/thumbs-up")

--- a/src/main/kotlin/org/teamsparta/moviereview/domain/post/dto/PostResponseWithThumbsUpAndComments.kt
+++ b/src/main/kotlin/org/teamsparta/moviereview/domain/post/dto/PostResponseWithThumbsUpAndComments.kt
@@ -1,0 +1,10 @@
+package org.teamsparta.moviereview.domain.post.dto
+
+import org.teamsparta.moviereview.domain.comment.model.Comment
+import org.teamsparta.moviereview.domain.post.model.Post
+
+data class PostResponseWithThumbsUpAndComments(
+    val post: Post,
+    val thumbsUpCount: Long,
+    val comments : List<Comment>,
+)

--- a/src/main/kotlin/org/teamsparta/moviereview/domain/post/model/search/Keyword.kt
+++ b/src/main/kotlin/org/teamsparta/moviereview/domain/post/model/search/Keyword.kt
@@ -8,7 +8,7 @@ import java.time.LocalDateTime
 
 @Entity
 class Keyword(
-    val searchWord: String,
+    val keyword: String,
     val createdAt: LocalDateTime
 ) {
     @Id
@@ -16,10 +16,10 @@ class Keyword(
     var id: Long? = null
 
     companion object {
-        fun of(searchWord: String): Keyword {
+        fun of(keyword: String): Keyword {
             val timestamp = LocalDateTime.now()
             return Keyword(
-                searchWord.replace(" ", ""),
+                keyword.replace(" ", ""),
                 createdAt = timestamp
             )
         }

--- a/src/main/kotlin/org/teamsparta/moviereview/domain/post/repository/v1/CustomPostRepository.kt
+++ b/src/main/kotlin/org/teamsparta/moviereview/domain/post/repository/v1/CustomPostRepository.kt
@@ -1,8 +1,9 @@
 package org.teamsparta.moviereview.domain.post.repository.v1
 
+import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
-import org.teamsparta.moviereview.domain.post.model.Post
+import org.teamsparta.moviereview.domain.post.dto.PostResponseWithThumbsUpAndComments
 
 interface CustomPostRepository {
-    fun findAllByPageableAndCategory(pageable: Pageable, category: String?): Triple<Long, List<Post>, List<Long>>
+    fun findAllByPageableAndKeyword(pageable: Pageable, keyword: String?): Page<PostResponseWithThumbsUpAndComments>
 }

--- a/src/main/kotlin/org/teamsparta/moviereview/domain/post/repository/v1/PostRepositoryImpl.kt
+++ b/src/main/kotlin/org/teamsparta/moviereview/domain/post/repository/v1/PostRepositoryImpl.kt
@@ -1,33 +1,46 @@
 package org.teamsparta.moviereview.domain.post.repository.v1
 
 import com.querydsl.core.BooleanBuilder
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Repository
 import org.teamsparta.moviereview.domain.comment.model.QComment
-import org.teamsparta.moviereview.domain.post.model.Category
-import org.teamsparta.moviereview.domain.post.model.Post
+import org.teamsparta.moviereview.domain.post.dto.PostResponseWithThumbsUpAndComments
 import org.teamsparta.moviereview.domain.post.model.QPost
+import org.teamsparta.moviereview.domain.post.model.search.Keyword
 import org.teamsparta.moviereview.domain.post.model.thumbsup.QThumbsUp
+import org.teamsparta.moviereview.domain.post.repository.v1.search.KeywordRepository
 import org.teamsparta.moviereview.domain.users.model.QUsers
 import org.teamsparta.moviereview.infra.querydsl.QueryDslSupport
+import java.time.LocalDateTime
 
 @Repository
-class PostRepositoryImpl : CustomPostRepository, QueryDslSupport() {
+class PostRepositoryImpl(private val keywordRepository: KeywordRepository) : CustomPostRepository, QueryDslSupport() {
 
     private val post = QPost.post
     private val comment = QComment.comment
     private val user = QUsers.users
     private val thumbsUp = QThumbsUp.thumbsUp
 
-    override fun findAllByPageableAndCategory(pageable: Pageable, category: String?): Triple<Long, List<Post>, List<Long>> {
+    override fun findAllByPageableAndKeyword(
+        pageable: Pageable,
+        keyword: String?
+    ): Page<PostResponseWithThumbsUpAndComments> {
 
         val whereClause = BooleanBuilder()
 
-        category?.let { whereClause.and(post.category.eq(Category.fromString(it))) }
+        keyword?.let {
+            whereClause.and(
+                post.title.containsIgnoreCase(it)
+                    .or(post.content.containsIgnoreCase(it))
+            )
+            saveSearchKeyword(it)
+        }
 
-        val totalCount = queryFactory.select(post.count()).from(post)
+        val totalCount = queryFactory.selectFrom(post)
             .where(whereClause)
-            .fetchOne() ?: 0L
+            .fetchCount()
 
         val posts = queryFactory.selectFrom(post)
             .leftJoin(post.user, user).fetchJoin()
@@ -37,17 +50,35 @@ class PostRepositoryImpl : CustomPostRepository, QueryDslSupport() {
             .limit(pageable.pageSize.toLong())
             .fetch()
 
-        val thumbsUpCounts = queryFactory.select(thumbsUp.count())
-            .from(post).leftJoin(thumbsUp)
-            .on(thumbsUp.postId.eq(post.id))
-            .where(whereClause)
-            .groupBy(post.id)
-            .orderBy(post.createdAt.desc())
-            .offset(pageable.offset)
-            .limit(pageable.pageSize.toLong())
+        val postIds = posts.map { it.id }
+
+        val thumbsUpCounts = queryFactory
+            .select(thumbsUp.postId, thumbsUp.count())
+            .from(thumbsUp)
+            .where(thumbsUp.postId.`in`(postIds))
+            .groupBy(thumbsUp.postId)
             .fetch()
+            .associate { it[thumbsUp.postId] to it[thumbsUp.count()] }
 
-        return Triple(totalCount, posts, thumbsUpCounts)
+        val commentsMap = queryFactory
+            .select(comment)
+            .where(comment.post.id.`in`(postIds))
+            .fetch()
+            .groupBy { it.post.id }
 
+        val postResponseWithThumbsUpAndComments = posts.map { post ->
+            PostResponseWithThumbsUpAndComments(
+                post = post,
+                thumbsUpCount = thumbsUpCounts[post.id] ?: -1L,
+                comments = commentsMap[post.id] ?: emptyList()
+            )
+        }
+
+        return PageImpl(postResponseWithThumbsUpAndComments, pageable, totalCount)
+    }
+
+    fun saveSearchKeyword(keyword: String) {
+        val keyword = Keyword(keyword = keyword, createdAt = LocalDateTime.now())
+        keywordRepository.save(keyword)
     }
 }

--- a/src/main/kotlin/org/teamsparta/moviereview/domain/post/service/v1/PostService.kt
+++ b/src/main/kotlin/org/teamsparta/moviereview/domain/post/service/v1/PostService.kt
@@ -2,10 +2,7 @@ package org.teamsparta.moviereview.domain.post.service.v1
 
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
-import org.teamsparta.moviereview.domain.post.dto.CreatePostRequest
-import org.teamsparta.moviereview.domain.post.dto.PostResponse
-import org.teamsparta.moviereview.domain.post.dto.PostResponseWithComments
-import org.teamsparta.moviereview.domain.post.dto.UpdatePostRequest
+import org.teamsparta.moviereview.domain.post.dto.*
 import org.teamsparta.moviereview.domain.post.dto.report.ReportPostRequest
 import org.teamsparta.moviereview.infra.security.UserPrincipal
 
@@ -15,7 +12,7 @@ interface PostService {
     fun createPost(principal: UserPrincipal, request: CreatePostRequest): PostResponse
     fun updatePost(principal: UserPrincipal, postId: Long, request: UpdatePostRequest)
     fun deletePost(principal: UserPrincipal, postId: Long)
-    fun searchPost(keyword: String): List<PostResponse>
+    fun searchPost(pageable: Pageable, keyword: String?): Page<PostResponseWithThumbsUpAndComments>
     fun thumbsUpPost(principal: UserPrincipal, postId: Long)
     fun cancelThumbsUpPost(principal: UserPrincipal, postId: Long)
     fun reportPost(principal: UserPrincipal, postId: Long, request: ReportPostRequest)

--- a/src/main/kotlin/org/teamsparta/moviereview/domain/post/service/v1/PostServiceImpl.kt
+++ b/src/main/kotlin/org/teamsparta/moviereview/domain/post/service/v1/PostServiceImpl.kt
@@ -1,7 +1,6 @@
 package org.teamsparta.moviereview.domain.post.service.v1
 
 import org.springframework.data.domain.Page
-import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
@@ -10,10 +9,7 @@ import org.teamsparta.moviereview.domain.comment.dto.CommentResponse
 import org.teamsparta.moviereview.domain.comment.repository.v1.CommentRepository
 import org.teamsparta.moviereview.domain.common.exception.AccessDeniedException
 import org.teamsparta.moviereview.domain.common.exception.ModelNotFoundException
-import org.teamsparta.moviereview.domain.post.dto.CreatePostRequest
-import org.teamsparta.moviereview.domain.post.dto.PostResponse
-import org.teamsparta.moviereview.domain.post.dto.PostResponseWithComments
-import org.teamsparta.moviereview.domain.post.dto.UpdatePostRequest
+import org.teamsparta.moviereview.domain.post.dto.*
 import org.teamsparta.moviereview.domain.post.dto.report.ReportPostRequest
 import org.teamsparta.moviereview.domain.post.model.Post
 import org.teamsparta.moviereview.domain.post.model.report.Report
@@ -33,11 +29,7 @@ class PostServiceImpl(
     private val reportRepository: ReportRepository
 ): PostService {
     override fun getPostList(pageable: Pageable, category: String?): Page<PostResponse> {
-        val (totalCount, post, thumbsUpCount) = postRepository.findAllByPageableAndCategory(pageable, category)
-
-        val postResponseList = post.zip(thumbsUpCount) { a, b -> PostResponse.from(a,b) }
-
-        return PageImpl(postResponseList, pageable, totalCount)
+        TODO("Not yet implemented")
     }
 
     @Transactional(readOnly = true)
@@ -47,7 +39,7 @@ class PostServiceImpl(
         val commentList = commentRepository.findAllByPostId(postId)
             .map { CommentResponse.fromEntity(it) }
 
-        return PostResponseWithComments.from(post, thumbsUpRepository.thumbsUpCount(postId), commentList)
+        return PostResponseWithComments.from(post, thumbsUpCount(postId), commentList)
     }
 
     override fun createPost(principal: UserPrincipal, request: CreatePostRequest): PostResponse {
@@ -79,12 +71,8 @@ class PostServiceImpl(
         thumbsUpRepository.deleteAllByPostId(postId)
     }
 
-    override fun searchPost(keyword: String): List<PostResponse> {
-        // 검색 기준 바탕으로 검색
-        // 페이지네이션 적용 예정
-
-        // 검색어 저장
-        TODO("Not yet implemented")
+    override fun searchPost(pageable: Pageable, keyword: String?): Page<PostResponseWithThumbsUpAndComments> {
+        return postRepository.findAllByPageableAndKeyword(pageable, keyword)
     }
 
     override fun thumbsUpPost(principal: UserPrincipal, postId: Long) {
@@ -142,7 +130,7 @@ class PostServiceImpl(
         return postRepository.existsById(postId)
     }
 
-    private fun ThumbsUpRepository.thumbsUpCount(postId: Long): Long {
+    private fun thumbsUpCount(postId: Long): Long {
         return thumbsUpRepository.countByPostId(postId)
     }
 }


### PR DESCRIPTION
## 🔥 연관된 이슈
#48 Feat: post column title&content 내에서 LIKE 사용해서 search

## 🍻 작업 내용
> searchPost 작업


## 🔨 참고사항 및 질문
> 그냥 모든 post를 반환하는 getPostList가 search 기능을 사용하는것 같아서 실제 api 명세에 맞게 refactor 필요
