### PR TITLE
✨ #48 - querydsl 사용해서 post의 title과 content내에 있는 keyword 검색 & keyword table에 저장

### DIFF
--- a/src/main/kotlin/org/teamsparta/moviereview/domain/post/controller/v1/PostController.kt
+++ b/src/main/kotlin/org/teamsparta/moviereview/domain/post/controller/v1/PostController.kt
@@ -71,9 +71,10 @@ class PostController(
 
     @GetMapping("/search")
     fun searchPost(
+        pageable: Pageable,
         @RequestParam keyword: String,
-        ) : ResponseEntity<List<PostResponse>> {
-        return ResponseEntity.ok(postService.searchPost(keyword))
+    ): ResponseEntity<Page<PostResponse>> {
+        return ResponseEntity.status(HttpStatus.OK).body(postService.searchPost(pageable, keyword))
     }
 
     @PostMapping("/{postId}/thumbs-up")

--- a/src/main/kotlin/org/teamsparta/moviereview/domain/post/repository/v1/CustomPostRepository.kt
+++ b/src/main/kotlin/org/teamsparta/moviereview/domain/post/repository/v1/CustomPostRepository.kt
@@ -1,8 +1,11 @@
 package org.teamsparta.moviereview.domain.post.repository.v1
 
+import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.teamsparta.moviereview.domain.post.dto.PostResponse
 import org.teamsparta.moviereview.domain.post.model.Post
 
 interface CustomPostRepository {
     fun findAllByPageableAndCategory(pageable: Pageable, category: String?): Triple<Long, List<Post>, List<Long>>
+    fun searchPostByPageableAndKeyword(pageable:Pageable, keyword:String?): Page<PostResponse>
 }

--- a/src/main/kotlin/org/teamsparta/moviereview/domain/post/repository/v1/PostRepositoryImpl.kt
+++ b/src/main/kotlin/org/teamsparta/moviereview/domain/post/repository/v1/PostRepositoryImpl.kt
@@ -1,9 +1,12 @@
 package org.teamsparta.moviereview.domain.post.repository.v1
 
 import com.querydsl.core.BooleanBuilder
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Repository
 import org.teamsparta.moviereview.domain.comment.model.QComment
+import org.teamsparta.moviereview.domain.post.dto.PostResponse
 import org.teamsparta.moviereview.domain.post.model.Category
 import org.teamsparta.moviereview.domain.post.model.Post
 import org.teamsparta.moviereview.domain.post.model.QPost
@@ -19,7 +22,10 @@ class PostRepositoryImpl : CustomPostRepository, QueryDslSupport() {
     private val user = QUsers.users
     private val thumbsUp = QThumbsUp.thumbsUp
 
-    override fun findAllByPageableAndCategory(pageable: Pageable, category: String?): Triple<Long, List<Post>, List<Long>> {
+    override fun findAllByPageableAndCategory(
+        pageable: Pageable,
+        category: String?
+    ): Triple<Long, List<Post>, List<Long>> {
 
         val whereClause = BooleanBuilder()
 
@@ -49,5 +55,55 @@ class PostRepositoryImpl : CustomPostRepository, QueryDslSupport() {
 
         return Triple(totalCount, posts, thumbsUpCounts)
 
+    }
+
+    override fun searchPostByPageableAndKeyword(
+        pageable: Pageable,
+        keyword: String?
+    ): Page<PostResponse> {
+        val whereClause = BooleanBuilder()
+
+        keyword?.let {
+            whereClause.and(
+                post.title.containsIgnoreCase(it)
+                    .or(post.content.containsIgnoreCase(it))
+            )
+        }
+
+        val totalCount = queryFactory.selectFrom(post)
+            .where(whereClause)
+            .fetchCount()
+
+        val posts = queryFactory.selectFrom(post)
+            .leftJoin(post.user, user).fetchJoin()
+            .where(whereClause)
+            .orderBy(post.createdAt.desc())
+            .offset(pageable.offset)
+            .limit(pageable.pageSize.toLong())
+            .fetch()
+
+        val postIds = posts.map { it.id }
+
+        val thumbsUpCounts = queryFactory
+            .select(thumbsUp.postId, thumbsUp.count())
+            .from(thumbsUp)
+            .where(thumbsUp.postId.`in`(postIds))
+            .groupBy(thumbsUp.postId)
+            .fetch()
+            .associate { it[thumbsUp.postId] to it[thumbsUp.count()] }
+
+        val postResponse = posts.map { post ->
+            PostResponse(
+                id = post.id!!,
+                title = post.title,
+                nickname = post.user.nickname,
+                content = post.content,
+                category = post.category.toString(),
+                thumbUpCount = thumbsUpCounts[post.id] ?: 0L,
+                createdAt = post.createdAt,
+                updatedAt = post.updatedAt
+            )
+        }
+        return PageImpl(postResponse, pageable, totalCount)
     }
 }

--- a/src/main/kotlin/org/teamsparta/moviereview/domain/post/repository/v1/PostRepositoryImpl.kt
+++ b/src/main/kotlin/org/teamsparta/moviereview/domain/post/repository/v1/PostRepositoryImpl.kt
@@ -70,9 +70,11 @@ class PostRepositoryImpl : CustomPostRepository, QueryDslSupport() {
             )
         }
 
-        val totalCount = queryFactory.selectFrom(post)
+        val totalCount = queryFactory.select(post.count())
+            .from(post)
             .where(whereClause)
-            .fetchCount()
+            .fetchOne() ?: -1L
+
 
         val posts = queryFactory.selectFrom(post)
             .leftJoin(post.user, user).fetchJoin()
@@ -99,7 +101,7 @@ class PostRepositoryImpl : CustomPostRepository, QueryDslSupport() {
                 nickname = post.user.nickname,
                 content = post.content,
                 category = post.category.toString(),
-                thumbUpCount = thumbsUpCounts[post.id] ?: 0L,
+                thumbUpCount = thumbsUpCounts[post.id] ?: -1L,
                 createdAt = post.createdAt,
                 updatedAt = post.updatedAt
             )

--- a/src/main/kotlin/org/teamsparta/moviereview/domain/post/service/v1/PostService.kt
+++ b/src/main/kotlin/org/teamsparta/moviereview/domain/post/service/v1/PostService.kt
@@ -2,10 +2,7 @@ package org.teamsparta.moviereview.domain.post.service.v1
 
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
-import org.teamsparta.moviereview.domain.post.dto.CreatePostRequest
-import org.teamsparta.moviereview.domain.post.dto.PostResponse
-import org.teamsparta.moviereview.domain.post.dto.PostResponseWithComments
-import org.teamsparta.moviereview.domain.post.dto.UpdatePostRequest
+import org.teamsparta.moviereview.domain.post.dto.*
 import org.teamsparta.moviereview.domain.post.dto.report.ReportPostRequest
 import org.teamsparta.moviereview.infra.security.UserPrincipal
 
@@ -15,7 +12,7 @@ interface PostService {
     fun createPost(principal: UserPrincipal, request: CreatePostRequest): PostResponse
     fun updatePost(principal: UserPrincipal, postId: Long, request: UpdatePostRequest)
     fun deletePost(principal: UserPrincipal, postId: Long)
-    fun searchPost(keyword: String): List<PostResponse>
+    fun searchPost(pageable: Pageable, keyword: String?): Page<PostResponse>
     fun thumbsUpPost(principal: UserPrincipal, postId: Long)
     fun cancelThumbsUpPost(principal: UserPrincipal, postId: Long)
     fun reportPost(principal: UserPrincipal, postId: Long, request: ReportPostRequest)

--- a/src/main/kotlin/org/teamsparta/moviereview/domain/post/service/v1/PostServiceImpl.kt
+++ b/src/main/kotlin/org/teamsparta/moviereview/domain/post/service/v1/PostServiceImpl.kt
@@ -16,13 +16,16 @@ import org.teamsparta.moviereview.domain.post.dto.PostResponseWithComments
 import org.teamsparta.moviereview.domain.post.dto.UpdatePostRequest
 import org.teamsparta.moviereview.domain.post.dto.report.ReportPostRequest
 import org.teamsparta.moviereview.domain.post.model.Post
+import org.teamsparta.moviereview.domain.post.model.keyword.Keyword
 import org.teamsparta.moviereview.domain.post.model.report.Report
 import org.teamsparta.moviereview.domain.post.model.thumbsup.ThumbsUp
 import org.teamsparta.moviereview.domain.post.repository.v1.PostRepository
+import org.teamsparta.moviereview.domain.post.repository.v1.keyword.KeywordRepository
 import org.teamsparta.moviereview.domain.post.repository.v1.report.ReportRepository
 import org.teamsparta.moviereview.domain.post.repository.v1.thumbsup.ThumbsUpRepository
 import org.teamsparta.moviereview.domain.users.repository.v1.UserRepository
 import org.teamsparta.moviereview.infra.security.UserPrincipal
+import java.time.LocalDateTime
 
 @Service
 class PostServiceImpl(
@@ -30,7 +33,8 @@ class PostServiceImpl(
     private val thumbsUpRepository: ThumbsUpRepository,
     private val userRepository: UserRepository,
     private val commentRepository: CommentRepository,
-    private val reportRepository: ReportRepository
+    private val reportRepository: ReportRepository,
+    private val keywordRepository: KeywordRepository
 ): PostService {
     override fun getPostList(pageable: Pageable, category: String?): Page<PostResponse> {
         val (totalCount, post, thumbsUpCount) = postRepository.findAllByPageableAndCategory(pageable, category)
@@ -79,12 +83,9 @@ class PostServiceImpl(
         thumbsUpRepository.deleteAllByPostId(postId)
     }
 
-    override fun searchPost(keyword: String): List<PostResponse> {
-        // 검색 기준 바탕으로 검색
-        // 페이지네이션 적용 예정
-
-        // 검색어 저장
-        TODO("Not yet implemented")
+    override fun searchPost(pageable: Pageable, keyword: String?): Page<PostResponse> {
+        keyword?.let { saveSearchKeyword(keyword) }
+        return postRepository.searchPostByPageableAndKeyword(pageable, keyword)
     }
 
     override fun thumbsUpPost(principal: UserPrincipal, postId: Long) {
@@ -144,5 +145,10 @@ class PostServiceImpl(
 
     private fun ThumbsUpRepository.thumbsUpCount(postId: Long): Long {
         return thumbsUpRepository.countByPostId(postId)
+    }
+
+    private fun saveSearchKeyword(keyword: String) {
+        val saveKeyword = Keyword(searchWord = keyword, createdAt = LocalDateTime.now())
+        keywordRepository.save(saveKeyword)
     }
 }

--- a/src/main/kotlin/org/teamsparta/moviereview/domain/post/service/v1/PostServiceImpl.kt
+++ b/src/main/kotlin/org/teamsparta/moviereview/domain/post/service/v1/PostServiceImpl.kt
@@ -148,7 +148,7 @@ class PostServiceImpl(
     }
 
     private fun saveSearchKeyword(keyword: String) {
-        val saveKeyword = Keyword(searchWord = keyword, createdAt = LocalDateTime.now())
+        val saveKeyword = Keyword.of(keyword)
         keywordRepository.save(saveKeyword)
     }
 }


### PR DESCRIPTION
## 🔥 연관된 이슈
#48 Feat: post column title&content 내에서 LIKE 사용해서 search

## 🍻 작업 내용
searchPost 작업