### PR TITLE
#71 🐛 - Cache 내부에 저장된 키워드는 재검색 시 Keyword 테이블에 저장되지 않는 문제 해결

### DIFF
--- a/src/main/kotlin/org/teamsparta/moviereview/MovieReviewApplication.kt
+++ b/src/main/kotlin/org/teamsparta/moviereview/MovieReviewApplication.kt
@@ -2,11 +2,12 @@ package org.teamsparta.moviereview
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
-import org.springframework.cache.annotation.EnableCaching
+import org.springframework.data.web.config.EnableSpringDataWebSupport
 import org.springframework.scheduling.annotation.EnableScheduling
 
 @SpringBootApplication
 @EnableScheduling
+@EnableSpringDataWebSupport(pageSerializationMode = EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO)
 class MovieReviewApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/org/teamsparta/moviereview/domain/post/controller/v2/PostController2.kt
+++ b/src/main/kotlin/org/teamsparta/moviereview/domain/post/controller/v2/PostController2.kt
@@ -13,12 +13,14 @@ import org.teamsparta.moviereview.domain.post.dto.PostResponseWithComments
 import org.teamsparta.moviereview.domain.post.dto.UpdatePostRequest
 import org.teamsparta.moviereview.domain.post.dto.report.ReportPostRequest
 import org.teamsparta.moviereview.domain.post.service.v2.PostService2
+import org.teamsparta.moviereview.domain.post.service.v2.SearchPostService2
 import org.teamsparta.moviereview.infra.security.UserPrincipal
 
 @RequestMapping("/api/v2/posts")
 @RestController
 class PostController2(
-    private val postService2: PostService2
+    private val postService2: PostService2,
+    private val searchPostService2 : SearchPostService2,
 ) {
 
     @GetMapping
@@ -66,7 +68,7 @@ class PostController2(
         pageable: Pageable,
         @RequestParam keyword: String,
     ): ResponseEntity<Page<PostResponse>> {
-        return ResponseEntity.status(HttpStatus.OK).body(postService2.searchPost(pageable, keyword))
+        return ResponseEntity.status(HttpStatus.OK).body(searchPostService2.searchPost(pageable, keyword))
     }
 
     @PostMapping("/{postId}/thumbs-up")

--- a/src/main/kotlin/org/teamsparta/moviereview/domain/post/controller/v3/PostController3.kt
+++ b/src/main/kotlin/org/teamsparta/moviereview/domain/post/controller/v3/PostController3.kt
@@ -12,13 +12,16 @@ import org.teamsparta.moviereview.domain.post.dto.PostResponse
 import org.teamsparta.moviereview.domain.post.dto.PostResponseWithComments
 import org.teamsparta.moviereview.domain.post.dto.UpdatePostRequest
 import org.teamsparta.moviereview.domain.post.dto.report.ReportPostRequest
+import org.teamsparta.moviereview.domain.post.service.v2.SearchPostService2
 import org.teamsparta.moviereview.domain.post.service.v3.PostService3
+import org.teamsparta.moviereview.domain.post.service.v3.SearchPostService3
 import org.teamsparta.moviereview.infra.security.UserPrincipal
 
 @RequestMapping("/api/v3/posts")
 @RestController
 class PostController3(
-    private val postService3: PostService3
+    private val postService3: PostService3,
+    private val searchPostService3 : SearchPostService3
 ) {
 
     @GetMapping
@@ -66,7 +69,7 @@ class PostController3(
         pageable: Pageable,
         @RequestParam keyword: String,
     ): ResponseEntity<Page<PostResponse>> {
-        return ResponseEntity.status(HttpStatus.OK).body(postService3.searchPost(pageable, keyword))
+        return ResponseEntity.status(HttpStatus.OK).body(searchPostService3.searchPost(pageable, keyword))
     }
 
     @PostMapping("/{postId}/thumbs-up")

--- a/src/main/kotlin/org/teamsparta/moviereview/domain/post/service/v1/PostService.kt
+++ b/src/main/kotlin/org/teamsparta/moviereview/domain/post/service/v1/PostService.kt
@@ -2,7 +2,10 @@ package org.teamsparta.moviereview.domain.post.service.v1
 
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
-import org.teamsparta.moviereview.domain.post.dto.*
+import org.teamsparta.moviereview.domain.post.dto.CreatePostRequest
+import org.teamsparta.moviereview.domain.post.dto.PostResponse
+import org.teamsparta.moviereview.domain.post.dto.PostResponseWithComments
+import org.teamsparta.moviereview.domain.post.dto.UpdatePostRequest
 import org.teamsparta.moviereview.domain.post.dto.report.ReportPostRequest
 import org.teamsparta.moviereview.infra.security.UserPrincipal
 
@@ -12,7 +15,7 @@ interface PostService {
     fun createPost(principal: UserPrincipal, request: CreatePostRequest): PostResponse
     fun updatePost(principal: UserPrincipal, postId: Long, request: UpdatePostRequest)
     fun deletePost(principal: UserPrincipal, postId: Long)
-    fun searchPost(pageable: Pageable, keyword: String?): Page<PostResponse>
+    fun searchPost(pageable: Pageable, keyword: String): Page<PostResponse>
     fun thumbsUpPost(principal: UserPrincipal, postId: Long)
     fun cancelThumbsUpPost(principal: UserPrincipal, postId: Long)
     fun reportPost(principal: UserPrincipal, postId: Long, request: ReportPostRequest)

--- a/src/main/kotlin/org/teamsparta/moviereview/domain/post/service/v1/PostServiceImpl.kt
+++ b/src/main/kotlin/org/teamsparta/moviereview/domain/post/service/v1/PostServiceImpl.kt
@@ -25,7 +25,6 @@ import org.teamsparta.moviereview.domain.post.repository.v1.report.ReportReposit
 import org.teamsparta.moviereview.domain.post.repository.v1.thumbsup.ThumbsUpRepository
 import org.teamsparta.moviereview.domain.users.repository.v1.UserRepository
 import org.teamsparta.moviereview.infra.security.UserPrincipal
-import java.time.LocalDateTime
 
 @Service
 class PostServiceImpl(
@@ -83,8 +82,8 @@ class PostServiceImpl(
         thumbsUpRepository.deleteAllByPostId(postId)
     }
 
-    override fun searchPost(pageable: Pageable, keyword: String?): Page<PostResponse> {
-        keyword?.let { saveSearchKeyword(keyword) }
+    override fun searchPost(pageable: Pageable, keyword: String): Page<PostResponse> {
+        keyword.let { saveSearchKeyword(keyword) }
         return postRepository.searchPostByPageableAndKeyword(pageable, keyword)
     }
 

--- a/src/main/kotlin/org/teamsparta/moviereview/domain/post/service/v2/PostService2.kt
+++ b/src/main/kotlin/org/teamsparta/moviereview/domain/post/service/v2/PostService2.kt
@@ -2,7 +2,10 @@ package org.teamsparta.moviereview.domain.post.service.v2
 
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
-import org.teamsparta.moviereview.domain.post.dto.*
+import org.teamsparta.moviereview.domain.post.dto.CreatePostRequest
+import org.teamsparta.moviereview.domain.post.dto.PostResponse
+import org.teamsparta.moviereview.domain.post.dto.PostResponseWithComments
+import org.teamsparta.moviereview.domain.post.dto.UpdatePostRequest
 import org.teamsparta.moviereview.domain.post.dto.report.ReportPostRequest
 import org.teamsparta.moviereview.infra.security.UserPrincipal
 
@@ -12,7 +15,7 @@ interface PostService2 {
     fun createPost(principal: UserPrincipal, request: CreatePostRequest): PostResponse
     fun updatePost(principal: UserPrincipal, postId: Long, request: UpdatePostRequest)
     fun deletePost(principal: UserPrincipal, postId: Long)
-    fun searchPostByKeyword(pageable: Pageable, keyword: String?): Page<PostResponse>
+    fun searchPostByKeyword(pageable: Pageable, keyword: String): Page<PostResponse>
     fun thumbsUpPost(principal: UserPrincipal, postId: Long)
     fun cancelThumbsUpPost(principal: UserPrincipal, postId: Long)
     fun reportPost(principal: UserPrincipal, postId: Long, request: ReportPostRequest)

--- a/src/main/kotlin/org/teamsparta/moviereview/domain/post/service/v2/PostService2.kt
+++ b/src/main/kotlin/org/teamsparta/moviereview/domain/post/service/v2/PostService2.kt
@@ -12,7 +12,7 @@ interface PostService2 {
     fun createPost(principal: UserPrincipal, request: CreatePostRequest): PostResponse
     fun updatePost(principal: UserPrincipal, postId: Long, request: UpdatePostRequest)
     fun deletePost(principal: UserPrincipal, postId: Long)
-    fun searchPost(pageable: Pageable, keyword: String?): Page<PostResponse>
+    fun searchPostByKeyword(pageable: Pageable, keyword: String?): Page<PostResponse>
     fun thumbsUpPost(principal: UserPrincipal, postId: Long)
     fun cancelThumbsUpPost(principal: UserPrincipal, postId: Long)
     fun reportPost(principal: UserPrincipal, postId: Long, request: ReportPostRequest)

--- a/src/main/kotlin/org/teamsparta/moviereview/domain/post/service/v2/PostServiceImpl2.kt
+++ b/src/main/kotlin/org/teamsparta/moviereview/domain/post/service/v2/PostServiceImpl2.kt
@@ -18,7 +18,6 @@ import org.teamsparta.moviereview.domain.post.dto.PostResponseWithComments
 import org.teamsparta.moviereview.domain.post.dto.UpdatePostRequest
 import org.teamsparta.moviereview.domain.post.dto.report.ReportPostRequest
 import org.teamsparta.moviereview.domain.post.model.Post
-import org.teamsparta.moviereview.domain.post.model.keyword.Keyword
 import org.teamsparta.moviereview.domain.post.model.report.Report
 import org.teamsparta.moviereview.domain.post.model.thumbsup.ThumbsUp
 import org.teamsparta.moviereview.domain.post.repository.v1.PostRepository
@@ -34,8 +33,7 @@ class PostServiceImpl2(
     private val thumbsUpRepository: ThumbsUpRepository,
     private val userRepository: UserRepository,
     private val commentRepository: CommentRepository,
-    private val reportRepository: ReportRepository,
-    private val keywordRepository: KeywordRepository
+    private val reportRepository: ReportRepository
 ) : PostService2 {
     override fun getPostList(pageable: Pageable, category: String?): Page<PostResponse> {
         val (totalCount, post, thumbsUpCount) = postRepository.findAllByPageableAndCategory(pageable, category)
@@ -86,8 +84,7 @@ class PostServiceImpl2(
     }
 
     @Cacheable("searchPostAOP", cacheManager = "caffeineCacheManager")
-    override fun searchPost(pageable: Pageable, keyword: String?): Page<PostResponse> {
-        keyword?.let { saveSearchKeyword(keyword) }
+    override fun searchPostByKeyword(pageable: Pageable, keyword: String?): Page<PostResponse> {
         return postRepository.searchPostByPageableAndKeyword(pageable, keyword)
     }
 
@@ -148,10 +145,5 @@ class PostServiceImpl2(
 
     private fun ThumbsUpRepository.thumbsUpCount(postId: Long): Long {
         return thumbsUpRepository.countByPostId(postId)
-    }
-
-    private fun saveSearchKeyword(keyword: String) {
-        val saveKeyword = Keyword.of(keyword)
-        keywordRepository.save(saveKeyword)
     }
 }

--- a/src/main/kotlin/org/teamsparta/moviereview/domain/post/service/v2/PostServiceImpl2.kt
+++ b/src/main/kotlin/org/teamsparta/moviereview/domain/post/service/v2/PostServiceImpl2.kt
@@ -21,7 +21,6 @@ import org.teamsparta.moviereview.domain.post.model.Post
 import org.teamsparta.moviereview.domain.post.model.report.Report
 import org.teamsparta.moviereview.domain.post.model.thumbsup.ThumbsUp
 import org.teamsparta.moviereview.domain.post.repository.v1.PostRepository
-import org.teamsparta.moviereview.domain.post.repository.v1.keyword.KeywordRepository
 import org.teamsparta.moviereview.domain.post.repository.v1.report.ReportRepository
 import org.teamsparta.moviereview.domain.post.repository.v1.thumbsup.ThumbsUpRepository
 import org.teamsparta.moviereview.domain.users.repository.v1.UserRepository
@@ -84,7 +83,7 @@ class PostServiceImpl2(
     }
 
     @Cacheable("searchPostAOP", cacheManager = "caffeineCacheManager")
-    override fun searchPostByKeyword(pageable: Pageable, keyword: String?): Page<PostResponse> {
+    override fun searchPostByKeyword(pageable: Pageable, keyword: String): Page<PostResponse> {
         return postRepository.searchPostByPageableAndKeyword(pageable, keyword)
     }
 

--- a/src/main/kotlin/org/teamsparta/moviereview/domain/post/service/v2/SearchPostService2.kt
+++ b/src/main/kotlin/org/teamsparta/moviereview/domain/post/service/v2/SearchPostService2.kt
@@ -12,8 +12,8 @@ class SearchPostService2(
     private val postService2 : PostService2,
     private val keywordRepository: KeywordRepository
 ) {
-    fun searchPost(pageable: Pageable, keyword: String?): Page<PostResponse> {
-        keyword?.let { saveSearchKeyword(keyword) }
+    fun searchPost(pageable: Pageable, keyword: String): Page<PostResponse> {
+        keyword.let { saveSearchKeyword(keyword) }
         return postService2.searchPostByKeyword(pageable, keyword)
     }
 

--- a/src/main/kotlin/org/teamsparta/moviereview/domain/post/service/v2/SearchPostService2.kt
+++ b/src/main/kotlin/org/teamsparta/moviereview/domain/post/service/v2/SearchPostService2.kt
@@ -1,0 +1,24 @@
+package org.teamsparta.moviereview.domain.post.service.v2
+
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+import org.teamsparta.moviereview.domain.post.dto.PostResponse
+import org.teamsparta.moviereview.domain.post.model.keyword.Keyword
+import org.teamsparta.moviereview.domain.post.repository.v1.keyword.KeywordRepository
+
+@Service
+class SearchPostService2(
+    private val postService2 : PostService2,
+    private val keywordRepository: KeywordRepository
+) {
+    fun searchPost(pageable: Pageable, keyword: String?): Page<PostResponse> {
+        keyword?.let { saveSearchKeyword(keyword) }
+        return postService2.searchPostByKeyword(pageable, keyword)
+    }
+
+    private fun saveSearchKeyword(keyword: String) {
+        val saveKeyword = Keyword.of(keyword)
+        keywordRepository.save(saveKeyword)
+    }
+}

--- a/src/main/kotlin/org/teamsparta/moviereview/domain/post/service/v2/keyword/KeywordServiceImpl2.kt
+++ b/src/main/kotlin/org/teamsparta/moviereview/domain/post/service/v2/keyword/KeywordServiceImpl2.kt
@@ -1,5 +1,6 @@
 package org.teamsparta.moviereview.domain.post.service.v2.keyword
 
+import org.springframework.cache.CacheManager
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
@@ -10,7 +11,8 @@ import java.time.LocalDateTime
 
 @Service
 class KeywordServiceImpl2(
-    private val keywordRepository: KeywordRepository
+    private val keywordRepository: KeywordRepository,
+    private val cacheManager: CacheManager
 ) : KeywordService2 {
 
     @Transactional
@@ -30,7 +32,12 @@ class KeywordServiceImpl2(
     override fun getHotKeywordsLastDay(): List<String> {
         val now = LocalDateTime.now()
         val from = now.minusDays(1)
-        return keywordRepository.getHotKeywords(from, now)
+        val hotKeywords = keywordRepository.getHotKeywords(from, now)
+
+        val cache = cacheManager.getCache("hotKeywordsLastDay")
+        cache?.put("top10", hotKeywords)
+
+        return hotKeywords
     }
 
     @Scheduled(cron = "0 0 0 * * ?")

--- a/src/main/kotlin/org/teamsparta/moviereview/domain/post/service/v3/PostService3.kt
+++ b/src/main/kotlin/org/teamsparta/moviereview/domain/post/service/v3/PostService3.kt
@@ -15,7 +15,7 @@ interface PostService3 {
     fun createPost(principal: UserPrincipal, request: CreatePostRequest): PostResponse
     fun updatePost(principal: UserPrincipal, postId: Long, request: UpdatePostRequest)
     fun deletePost(principal: UserPrincipal, postId: Long)
-    fun searchPostByKeyword(pageable: Pageable, keyword: String?): Page<PostResponse>
+    fun searchPostByKeyword(pageable: Pageable, keyword: String): Page<PostResponse>
     fun thumbsUpPost(principal: UserPrincipal, postId: Long)
     fun cancelThumbsUpPost(principal: UserPrincipal, postId: Long)
     fun reportPost(principal: UserPrincipal, postId: Long, request: ReportPostRequest)

--- a/src/main/kotlin/org/teamsparta/moviereview/domain/post/service/v3/PostService3.kt
+++ b/src/main/kotlin/org/teamsparta/moviereview/domain/post/service/v3/PostService3.kt
@@ -15,7 +15,7 @@ interface PostService3 {
     fun createPost(principal: UserPrincipal, request: CreatePostRequest): PostResponse
     fun updatePost(principal: UserPrincipal, postId: Long, request: UpdatePostRequest)
     fun deletePost(principal: UserPrincipal, postId: Long)
-    fun searchPost(pageable: Pageable, keyword: String?): Page<PostResponse>
+    fun searchPostByKeyword(pageable: Pageable, keyword: String?): Page<PostResponse>
     fun thumbsUpPost(principal: UserPrincipal, postId: Long)
     fun cancelThumbsUpPost(principal: UserPrincipal, postId: Long)
     fun reportPost(principal: UserPrincipal, postId: Long, request: ReportPostRequest)

--- a/src/main/kotlin/org/teamsparta/moviereview/domain/post/service/v3/PostServiceImpl3.kt
+++ b/src/main/kotlin/org/teamsparta/moviereview/domain/post/service/v3/PostServiceImpl3.kt
@@ -87,7 +87,7 @@ class PostServiceImpl3(
     }
 
     @Cacheable("searchPostRedis", cacheManager = "redisCacheManager")
-    override fun searchPostByKeyword(pageable: Pageable, keyword: String?): Page<PostResponse> {
+    override fun searchPostByKeyword(pageable: Pageable, keyword: String): Page<PostResponse> {
         return postRepository.searchPostByPageableAndKeyword(pageable, keyword)
     }
 

--- a/src/main/kotlin/org/teamsparta/moviereview/domain/post/service/v3/PostServiceImpl3.kt
+++ b/src/main/kotlin/org/teamsparta/moviereview/domain/post/service/v3/PostServiceImpl3.kt
@@ -18,7 +18,6 @@ import org.teamsparta.moviereview.domain.post.dto.PostResponseWithComments
 import org.teamsparta.moviereview.domain.post.dto.UpdatePostRequest
 import org.teamsparta.moviereview.domain.post.dto.report.ReportPostRequest
 import org.teamsparta.moviereview.domain.post.model.Post
-import org.teamsparta.moviereview.domain.post.model.keyword.Keyword
 import org.teamsparta.moviereview.domain.post.model.report.Report
 import org.teamsparta.moviereview.domain.post.model.thumbsup.ThumbsUp
 import org.teamsparta.moviereview.domain.post.repository.v1.PostRepository
@@ -148,10 +147,5 @@ class PostServiceImpl3(
 
     private fun ThumbsUpRepository.thumbsUpCount(postId: Long): Long {
         return thumbsUpRepository.countByPostId(postId)
-    }
-
-    private fun saveSearchKeyword(keyword: String) {
-        val saveKeyword = Keyword.of(keyword)
-        keywordRepository.save(saveKeyword)
     }
 }

--- a/src/main/kotlin/org/teamsparta/moviereview/domain/post/service/v3/PostServiceImpl3.kt
+++ b/src/main/kotlin/org/teamsparta/moviereview/domain/post/service/v3/PostServiceImpl3.kt
@@ -87,8 +87,7 @@ class PostServiceImpl3(
     }
 
     @Cacheable("searchPostRedis", cacheManager = "redisCacheManager")
-    override fun searchPost(pageable: Pageable, keyword: String?): Page<PostResponse> {
-        keyword?.let { saveSearchKeyword(keyword) }
+    override fun searchPostByKeyword(pageable: Pageable, keyword: String?): Page<PostResponse> {
         return postRepository.searchPostByPageableAndKeyword(pageable, keyword)
     }
 

--- a/src/main/kotlin/org/teamsparta/moviereview/domain/post/service/v3/SearchPostService3.kt
+++ b/src/main/kotlin/org/teamsparta/moviereview/domain/post/service/v3/SearchPostService3.kt
@@ -12,8 +12,8 @@ class SearchPostService3(
     private val postService3 : PostService3,
     private val keywordRepository: KeywordRepository
 ) {
-    fun searchPost(pageable: Pageable, keyword: String?): Page<PostResponse> {
-        keyword?.let { saveSearchKeyword(keyword) }
+    fun searchPost(pageable: Pageable, keyword: String): Page<PostResponse> {
+        keyword.let { saveSearchKeyword(keyword) }
         return postService3.searchPostByKeyword(pageable, keyword)
     }
 

--- a/src/main/kotlin/org/teamsparta/moviereview/domain/post/service/v3/SearchPostService3.kt
+++ b/src/main/kotlin/org/teamsparta/moviereview/domain/post/service/v3/SearchPostService3.kt
@@ -1,0 +1,24 @@
+package org.teamsparta.moviereview.domain.post.service.v3
+
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+import org.teamsparta.moviereview.domain.post.dto.PostResponse
+import org.teamsparta.moviereview.domain.post.model.keyword.Keyword
+import org.teamsparta.moviereview.domain.post.repository.v1.keyword.KeywordRepository
+
+@Service
+class SearchPostService3(
+    private val postService3 : PostService3,
+    private val keywordRepository: KeywordRepository
+) {
+    fun searchPost(pageable: Pageable, keyword: String?): Page<PostResponse> {
+        keyword?.let { saveSearchKeyword(keyword) }
+        return postService3.searchPostByKeyword(pageable, keyword)
+    }
+
+    private fun saveSearchKeyword(keyword: String) {
+        val saveKeyword = Keyword.of(keyword)
+        keywordRepository.save(saveKeyword)
+    }
+}


### PR DESCRIPTION
## 🔥 연관된 이슈
#71 

## 🍻 작업 내용
> SearchPostService 생성 AOP 내부호출 문제 해결
> 이미 Cache 내부에 저장된 키워드를 재검색하여도 테이블에 새롭게 저장되도록 Method 분리 진행